### PR TITLE
Build one arch

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -53,24 +53,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy ${{ matrix.dockerfile[1] }}
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/build-push-action@v2
-        with:
-          file: docker/${{matrix.dockerfile[1]}}
-          platforms: ${{ matrix.dockerfile[2] }}
-          context: .
-          push: true
-          tags: ghcr.io/buildsi/${{ env.container }}
-
       - name: Build ${{ matrix.dockerfile[1] }}
-        if: ${{ github.event_name == 'pull_request' }}
         uses: docker/build-push-action@v2
         with:
           file: docker/${{matrix.dockerfile[1]}}
           platforms: ${{ matrix.dockerfile[2] }}
           context: .
-          load: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/buildsi/${{ env.container }}
 
       - name: Label

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -80,4 +80,4 @@ jobs:
           labels=$(echo $(tr '\r\n' '|' < compilers.txt))
           labels="org.spack.compilers=${labels}"
           printf "Saving compiler labels ${labels}\n"         
-          crane mutate ${{ env.container }} --label "${labels}"
+          crane mutate ghcr.io/buildsi/${{ env.container }} --label "${labels}"

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -53,13 +53,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build ${{ matrix.dockerfile[1] }}
+      - name: Deploy ${{ matrix.dockerfile[1] }}
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/build-push-action@v2
         with:
           file: docker/${{matrix.dockerfile[1]}}
           platforms: ${{ matrix.dockerfile[2] }}
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          tags: ghcr.io/buildsi/${{ env.container }}
+
+      - name: Build ${{ matrix.dockerfile[1] }}
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/${{matrix.dockerfile[1]}}
+          platforms: ${{ matrix.dockerfile[2] }}
+          context: .
+          load: true
           tags: ghcr.io/buildsi/${{ env.container }}
 
       - name: Label

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -10,17 +10,20 @@ jobs:
       fail-fast: false
       matrix:
                     # tag           dockerfile in docker/     platforms
-        dockerfile: [[ubuntu-18.04, Dockerfile.ubuntu-18.04, 'linux/amd64,linux/ppc64le,linux/arm64'],
-                     [ubuntu-20.04, Dockerfile.ubuntu-20.04, 'linux/amd64,linux/ppc64le,linux/arm64'],
-                     [centos-7, Dockerfile.centos-7, 'linux/amd64,linux/ppc64le,linux/arm64'],
-                     [centos-8, Dockerfile.centos-8, 'linux/amd64,linux/ppc64le,linux/arm64'],
-                     [fedora, Dockerfile.fedora, 'linux/amd64']] # others are very slow
+        dockerfile: [[ubuntu-18.04, Dockerfile.ubuntu-18.04, 'linux/amd64'],
+                     [ubuntu-20.04, Dockerfile.ubuntu-20.04, 'linux/amd64'],
+                     [centos-7, Dockerfile.centos-7, 'linux/amd64'],
+                     [centos-8, Dockerfile.centos-8, 'linux/amd64'],
+                     [fedora, Dockerfile.fedora, 'linux/amd64']]
 
     name: Build ${{ matrix.dockerfile[0] }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
+      - uses: actions/setup-go@v2
+      - uses: imjasonh/setup-crane@01d26682810dcd47bfc8eb1efe791558123a9373
+      - name: Display GitHub Action architecture
+        run: lscpu
       - name: Set Container Tag
         run: |
           container="spack-${{ matrix.dockerfile[0] }}:latest"
@@ -50,31 +53,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # We only do this to derive the labels!
-      - name: Build ${{ matrix.dockerfile[1] }}
-        uses: docker/build-push-action@v2
-        with:
-          file: docker/${{matrix.dockerfile[1]}}
-          platforms: linux/amd64
-          context: .
-          load: true
-          tags: ghcr.io/buildsi/${{ env.container }}
-
-      - name: Derive Compiler Labels
-        id: labels
-        run: |
-          docker run -i --rm ghcr.io/buildsi/${{ env.container }} spack compiler list --flat > compilers.txt
-          labels=$(echo $(tr '\r\n' ',' < compilers.txt))
-          labels="org.spack.compilers=${labels}"
-          printf "Saving compiler labels ${labels}\n"         
-          echo "compiler_labels=${labels}" >> $GITHUB_ENV
-      
       - name: Deploy ${{ matrix.dockerfile[1] }}
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/build-push-action@v2
         with:
           file: docker/${{matrix.dockerfile[1]}}
           platforms: ${{ matrix.dockerfile[2] }}
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ghcr.io/buildsi/${{ env.container }}
-          labels: ${{ env.compiler_labels }}
+
+      - name: Build ${{ matrix.dockerfile[1] }}
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/${{matrix.dockerfile[1]}}
+          platforms: ${{ matrix.dockerfile[2] }}
+          context: .
+          load: true
+          tags: ghcr.io/buildsi/${{ env.container }}
+
+      - name: Label
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          docker run -i --rm ghcr.io/buildsi/${{ env.container }} spack compiler list --flat > compilers.txt
+          labels=$(echo $(tr '\r\n' '|' < compilers.txt))
+          labels="org.spack.compilers=${labels}"
+          printf "Saving compiler labels ${labels}\n"         
+          crane mutate ${{ env.container }} --label "${labels}"

--- a/.github/workflows/gcc-matrices.yaml
+++ b/.github/workflows/gcc-matrices.yaml
@@ -56,6 +56,9 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
 
+    - name: Display GitHub Action architecture
+      run: lscpu
+
     - name: GHCR Login
       if: (github.event_name != 'pull_request')
       uses: docker/login-action@v1 
@@ -108,30 +111,15 @@ jobs:
         context: ${{ env.dockerfile_dir }}
         file: ${{ env.filename }}
         platforms: ${{ matrix.arch[0] }}
-        load: true
+        push: ${{ github.event_name != 'pull_request' }}
         build-args: |
           ${{ env.build_args }}
           anaconda_url=${{ matrix.arch[1] }}
         tags: ghcr.io/buildsi/${{ env.container }}
 
-    - name: Derive Compiler Labels
-      id: labels
+    - name: Add Compiler Labels
       run: |
         docker run -i --rm ghcr.io/buildsi/${{ env.container }} spack compiler list --flat > compilers.txt
         labels=$(echo $(tr '\r\n' ',' < compilers.txt))
         labels="org.spack.compilers=${labels}"
-        printf "Saving compiler labels ${labels}\n"         
-        echo "compiler_labels=${labels}" >> $GITHUB_ENV
-      
-    - name: Deploy ${{ matrix.dockerfile[1] }}
-      uses: docker/build-push-action@v2
-      with:
-        context: ${{ env.dockerfile_dir }}
-        file: ${{ env.filename }}
-        platforms: ${{ matrix.arch[0] }}
-        push: ${{ github.event_name != 'pull_request' }}
-        build-args: |
-            ${{ env.build_args }}
-            anaconda_url=${{ matrix.arch[1] }}
-        tags: ghcr.io/buildsi/${{ env.container }}
-        labels: ${{ env.compiler_labels }}
+        printf "Adding compiler labels ${labels}\n"

--- a/.github/workflows/gcc-matrices.yaml
+++ b/.github/workflows/gcc-matrices.yaml
@@ -55,7 +55,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
-
+    - uses: actions/setup-go@v2
+    - uses: imjasonh/setup-crane@01d26682810dcd47bfc8eb1efe791558123a9373
     - name: Display GitHub Action architecture
       run: lscpu
 
@@ -120,6 +121,7 @@ jobs:
     - name: Add Compiler Labels
       run: |
         docker run -i --rm ghcr.io/buildsi/${{ env.container }} spack compiler list --flat > compilers.txt
-        labels=$(echo $(tr '\r\n' ',' < compilers.txt))
+        labels=$(echo $(tr '\r\n' '|' < compilers.txt))
         labels="org.spack.compilers=${labels}"
         printf "Adding compiler labels ${labels}\n"
+        crane mutate ghcr.io/buildsi/${{ env.container }} --label "${labels}"

--- a/docker/Dockerfile.centos-7
+++ b/docker/Dockerfile.centos-7
@@ -59,7 +59,7 @@ RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
     spack compiler find && \
-    spack install libabigail+docs
+    spack install libabigail
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/Dockerfile.centos-7
+++ b/docker/Dockerfile.centos-7
@@ -49,6 +49,7 @@ RUN yum update -y \
   && yum clean all
 
 ENV SPACK_ROOT=/opt/spack
+ENV SPACK_ADD_DEBUG_FLAGS=true
 
 RUN python3 -m pip install --upgrade pip setuptools wheel \
  && python3 -m pip install gnureadline boto3 pyyaml pytz minio requests clingo \
@@ -57,7 +58,8 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
 RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
-    spack compiler find
+    spack compiler find && \
+    spack install libabigail+docs
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -47,6 +47,7 @@ RUN yum update -y \
   && yum clean all
 
 ENV SPACK_ROOT=/opt/spack
+ENV SPACK_ADD_DEBUG_FLAGS=true
 
 RUN python3 -m pip install --upgrade pip setuptools wheel \
  && python3 -m pip install gnureadline boto3 pyyaml pytz minio requests clingo \
@@ -55,7 +56,8 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
 RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
-    spack compiler find
+    spack compiler find && \
+    spack install libabigail+docs
     
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -57,8 +57,8 @@ RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
     spack compiler find && \
-    spack install libabigail+docs
-    
+    spack install libabigail
+ 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \
     python3 -m pip install .

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -71,7 +71,7 @@ RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
     spack compiler find && \
-    spack install libabigail+docs
+    spack install libabigail
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -65,11 +65,13 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
  && rm -rf ~/.cache
 
 ENV SPACK_ROOT=/opt/spack
+ENV SPACK_ADD_DEBUG_FLAGS=true
     
 RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
-    spack compiler find
+    spack compiler find && \
+    spack install libabigail+docs
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/Dockerfile.ubuntu-18.04
+++ b/docker/Dockerfile.ubuntu-18.04
@@ -64,7 +64,7 @@ RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
     spack compiler find && \
-    spack install libabigail+docs
+    spack install libabigail
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/Dockerfile.ubuntu-18.04
+++ b/docker/Dockerfile.ubuntu-18.04
@@ -58,11 +58,13 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
  && rm -rf ~/.cache
 
 ENV SPACK_ROOT=/opt/spack    
+ENV SPACK_ADD_DEBUG_FLAGS=true
 
 RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
-    spack compiler find
+    spack compiler find && \
+    spack install libabigail+docs
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/Dockerfile.ubuntu-20.04
+++ b/docker/Dockerfile.ubuntu-20.04
@@ -65,7 +65,7 @@ RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
     spack compiler find && \
-    spack install libabigail+docs
+    spack install libabigail
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/Dockerfile.ubuntu-20.04
+++ b/docker/Dockerfile.ubuntu-20.04
@@ -59,11 +59,13 @@ RUN python -m pip install --upgrade pip setuptools wheel \
  && rm -rf ~/.cache
 
 ENV SPACK_ROOT=/opt/spack
+ENV SPACK_ADD_DEBUG_FLAGS=true
     
 RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
-    spack compiler find
+    spack compiler find && \
+    spack install libabigail+docs
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -64,11 +64,13 @@ RUN wget https://repo.anaconda.com/archive/${anaconda_url} && \
 
 ENV PATH=/opt/anaconda3/bin:$PATH
 ENV SPACK_ROOT=/opt/spack
+ENV SPACK_ADD_DEBUG_FLAGS=true
     
 RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
-    spack compiler find
+    spack compiler find && \
+    spack install libabigail+docs
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -70,7 +70,7 @@ RUN git clone -b vsoch/db-17 https://github.com/vsoch/spack /opt/spack && \
     cd /opt/spack && \
     . share/spack/setup-env.sh && \
     spack compiler find && \
-    spack install libabigail+docs
+    spack install libabigail
 
 RUN git clone https://github.com/buildsi/symbolator && \
     cd symbolator && \

--- a/scripts/generate-matrix.py
+++ b/scripts/generate-matrix.py
@@ -38,7 +38,7 @@ def main():
         if not labels:
             labels = ["all"]
         else:
-            labels = [x for x in labels.strip(",").split(",") if x]
+            labels = [x for x in labels.strip("|").split("|") if x]
         # programatically get labels or default to "all compilers in the image"
         for label in labels:
             matrix.append([container, label])


### PR DESCRIPTION
This seems like the best approach for now - streamline the build time for one arch (since that's all we use anyway) and apply the label with crane instead of a rebuild.

This also installs libabigail in the base image to reduce analysis time.